### PR TITLE
Added healthTip

### DIFF
--- a/scripts/vcs-cli/vcs
+++ b/scripts/vcs-cli/vcs
@@ -569,8 +569,8 @@ def cluster_ls(args):
 
 def all_ls_headers():
     """ Return a list of all header for ls -l """
-    return ['Name', 'Type', 'State', 'Health', 'Slave_Count', 'ETCD_IP',
-            'Master_IP', 'UUID', 'Health_Tip']
+    return ['Name', 'Type', 'State', 'Health', 'Reason',
+            'Slaves', 'ETCD_IP', 'Master_IP', 'UUID']
 
 
 def generate_ls_rows(known_clusters):
@@ -580,20 +580,24 @@ def generate_ls_rows(known_clusters):
         resp = requests.get(VCS_HOST + cluster)
         cluster_info = resp.json()
         ext_info = cluster_info['extendedProperties']
-        if 'healthTip' in cluster_info:
-            health_tip = cluster_info['healthTip']
+        if cluster_info['clusterState'] == "CREATING":
+            health = "n/a"
         else:
-            health_tip = "n/a"
+            health = cluster_info['clusterhealth']
+        if 'healthTip' in cluster_info:
+            reason = cluster_info['healthTip']
+        else:
+            reason = "n/a"
         rows.append([
             cluster_info['clusterName'],
             cluster_info['clusterType'],
             cluster_info['clusterState'],
-            cluster_info['clusterhealth'],
+            health,
+            reason,
             str(cluster_info['slaveCount']),
             ext_info['etcd_ips'],
             ext_info['master_ip'],
-            os.path.basename(cluster_info['documentSelfLink']),
-            health_tip
+            os.path.basename(cluster_info['documentSelfLink'])
         ])
     return rows
 

--- a/scripts/vcs-cli/vcs
+++ b/scripts/vcs-cli/vcs
@@ -570,7 +570,7 @@ def cluster_ls(args):
 def all_ls_headers():
     """ Return a list of all header for ls -l """
     return ['Name', 'Type', 'State', 'Health', 'Slave_Count', 'ETCD_IP',
-            'Master_IP', 'UUID']
+            'Master_IP', 'UUID', 'Health_Tip']
 
 
 def generate_ls_rows(known_clusters):
@@ -580,6 +580,10 @@ def generate_ls_rows(known_clusters):
         resp = requests.get(VCS_HOST + cluster)
         cluster_info = resp.json()
         ext_info = cluster_info['extendedProperties']
+        if 'healthTip' in cluster_info:
+            health_tip = cluster_info['healthTip']
+        else:
+            health_tip = "n/a"
         rows.append([
             cluster_info['clusterName'],
             cluster_info['clusterType'],
@@ -588,7 +592,8 @@ def generate_ls_rows(known_clusters):
             str(cluster_info['slaveCount']),
             ext_info['etcd_ips'],
             ext_info['master_ip'],
-            os.path.basename(cluster_info['documentSelfLink'])
+            os.path.basename(cluster_info['documentSelfLink']),
+            health_tip
         ])
     return rows
 


### PR DESCRIPTION
//CC @SandeepPissay 

Added healthTip (as  "Reason" column) and  hid 'Health' for CREATING clusters
Examples: 
```
$ VCS_HOST=http://10.160.247.176:19000 vcs cluster ls
Name           Type        State  Health  Reason                           Slaves  ETCD_IP      Master_IP    UUID                                  
-------------  ----------  -----  ------  -------------------------------  ------  -----------  -----------  ------------------------------------  
testCluster-1  KUBERNETES  READY  RED     Slaves not healthy : 172.16.0.2  2       172.16.0.15  172.16.0.17  d4960416-0ce5-413d-af1d-23947dd4e296  

```

and 
```
$ VCS_HOST=http://10.162.37.32:19000 vcs cluster ls
Name      Type        State     Health  Reason  Slaves  ETCD_IP       Master_IP    UUID                                  
--------  ----------  --------  ------  ------  ------  ------------  -----------  ------------------------------------  
cluster2  KUBERNETES  READY     GREEN   n/a     2       172.16.0.8    172.16.0.9   3553880b-d224-49a9-a421-e9dab72d2ff9  
cluster3  KUBERNETES  READY     GREEN   n/a     1       172.16.0.11   172.16.0.12  bebc5313-ec27-4cd4-908e-31f7d82b164a  
msterin1  KUBERNETES  CREATING  n/a     n/a     3       172.16.0.112  172.16.0.91  924f3369-f32f-48c3-bbd4-4134b31d6f5f
```
